### PR TITLE
Replace "/" character by "."

### DIFF
--- a/admin/jsonadm/src/Admin/JsonAdm/Base.php
+++ b/admin/jsonadm/src/Admin/JsonAdm/Base.php
@@ -237,7 +237,7 @@ abstract class Base
 			$manager = \Aimeos\MShop\Factory::createManager( $context, $domain );
 
 			$search = $manager->createSearch();
-			$search->setConditions( $search->compare( '==', $domain . '.id', $ids ) );
+			$search->setConditions( $search->compare( '==', str_replace( '/', '.', $domain ) . '.id', $ids ) );
 
 			$list = array_merge( $list, $manager->searchItems( $search ) );
 		}


### PR DESCRIPTION
"/" character must be replaced by "." to avoid invalid name problem when trying to include relationships when getting resources.