### PR TITLE
Fix relationship structure in partial templates to comply with jsonapi.org and main template

### DIFF
--- a/admin/jsonadm/templates/partials/catalog/data-standard.php
+++ b/admin/jsonadm/templates/partials/catalog/data-standard.php
@@ -50,7 +50,7 @@ $build = function( \Aimeos\MShop\Catalog\Item\Iface $item, \Aimeos\Map $listItem
 	foreach( $item->getChildren() as $childItem )
 	{
 		$type = $childItem->getResourceType();
-		$result['relationships'][$type][] = array( 'data' => array( 'id' => $childItem->getId(), 'type' => $type ) );
+		$result['relationships'][$type]['data'][] = ['id' => $childItem->getId(), 'type' => $type];
 	}
 
 	foreach( $listItems as $listId => $listItem )
@@ -60,14 +60,14 @@ $build = function( \Aimeos\MShop\Catalog\Item\Iface $item, \Aimeos\Map $listItem
 			$type = $listItem->getDomain();
 			$params = array( 'resource' => $listItem->getResourceType(), 'id' => $listId );
 
-			$result['relationships'][$type][] = array( 'data' => array(
+			$result['relationships'][$type]['data'][] = [
 				'id' => $listItem->getRefId(),
 				'type' => $type,
 				'attributes' => $listItem->toArray( true ),
 				'links' => array(
 					'self' => $this->url( $target, $cntl, $action, $params, [], $config )
 				)
-			) );
+			];
 		}
 	}
 

--- a/admin/jsonadm/templates/partials/locale/site/data-standard.php
+++ b/admin/jsonadm/templates/partials/locale/site/data-standard.php
@@ -50,7 +50,7 @@ $build = function( \Aimeos\MShop\Locale\Item\Site\Iface $item ) use ( $fields )
 	foreach( $item->getChildren() as $childItem )
 	{
 		$type = $childItem->getResourceType();
-		$result['relationships'][$type][] = array( 'data' => array( 'id' => $childItem->getId(), 'type' => $type ) );
+		$result['relationships'][$type]['data'][] = ['id' => $childItem->getId(), 'type' => $type];
 	}
 
 	return $result;

--- a/admin/jsonadm/templates/partials/order/base/data-standard.php
+++ b/admin/jsonadm/templates/partials/order/base/data-standard.php
@@ -54,11 +54,11 @@ $build = function( \Aimeos\MShop\Order\Item\Base\Iface $item, \Aimeos\Map $child
 			$type = $childItem->getResourceType();
 			$params = array( 'resource' => $childItem->getResourceType(), 'id' => $childItem->getId() );
 
-			$result['relationships'][$type][] = array( 'data' => array(
+			$result['relationships'][$type]['data'][] = [
 				'id' => $childItem->getId(), 'type' => $type, 'links' => array(
 					'self' => $this->url( $target, $cntl, $action, $params, [], $config )
 				)
-			) );
+			];
 		}
 	}
 

--- a/admin/jsonadm/templates/partials/order/data-standard.php
+++ b/admin/jsonadm/templates/partials/order/data-standard.php
@@ -56,12 +56,12 @@ $build = function( \Aimeos\MShop\Order\Item\Iface $item, \Aimeos\Map $childItems
 			$type = $childItem->getResourceType();
 			$params = array( 'resource' => $childItem->getResourceType(), 'id' => $childItem->getId() );
 
-			$result['relationships'][$type][] = array( 'data' => array(
+			$result['relationships'][$type]['data'][] = [
 				'id' => $childItem->getId(), 'type' => $type,
 				'links' => array(
 					'self' => $this->url( $target, $cntl, $action, $params, [], $config )
 				)
-			) );
+			];
 		}
 	}
 

--- a/admin/jsonadm/tests/Admin/JsonAdm/Catalog/StandardTest.php
+++ b/admin/jsonadm/tests/Admin/JsonAdm/Catalog/StandardTest.php
@@ -53,10 +53,11 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals( 200, $response->getStatusCode() );
 		$this->assertEquals( 1, count( $response->getHeader( 'Content-Type' ) ) );
 
+		error_log(print_r($result, true));
 		$this->assertEquals( 1, $result['meta']['total'] );
 		$this->assertEquals( 1, count( $result['data'] ) );
 		$this->assertEquals( 'catalog', $result['data'][0]['type'] );
-		$this->assertEquals( 6, count( $result['data'][0]['relationships']['text'] ) );
+		$this->assertEquals( 6, count( $result['data'][0]['relationships']['text']['data'] ) );
 		$this->assertEquals( 6, count( $result['included'] ) );
 
 		$this->assertArrayNotHasKey( 'errors', $result );
@@ -80,7 +81,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertEquals( 1, $result['meta']['total'] );
 		$this->assertEquals( 'catalog', $result['data']['type'] );
-		$this->assertEquals( 2, count( $result['data']['relationships']['catalog'] ) );
+		$this->assertEquals( 2, count( $result['data']['relationships']['catalog']['data'] ) );
 		$this->assertEquals( 2, count( $result['included'] ) );
 
 		$this->assertArrayNotHasKey( 'errors', $result );

--- a/admin/jsonadm/tests/Admin/JsonAdm/Catalog/StandardTest.php
+++ b/admin/jsonadm/tests/Admin/JsonAdm/Catalog/StandardTest.php
@@ -53,7 +53,6 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals( 200, $response->getStatusCode() );
 		$this->assertEquals( 1, count( $response->getHeader( 'Content-Type' ) ) );
 
-		error_log(print_r($result, true));
 		$this->assertEquals( 1, $result['meta']['total'] );
 		$this->assertEquals( 1, count( $result['data'] ) );
 		$this->assertEquals( 'catalog', $result['data'][0]['type'] );

--- a/admin/jsonadm/tests/Admin/JsonAdm/Order/Base/StandardTest.php
+++ b/admin/jsonadm/tests/Admin/JsonAdm/Order/Base/StandardTest.php
@@ -50,7 +50,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals( 'order/base', $result['data'][0]['type'] );
 		$this->assertEquals( 2, count( $result['data'][0]['relationships'] ) );
 		$this->assertEquals( 1, count( $result['data'][0]['relationships']['order/base/address'] ) );
-		$this->assertEquals( 6, count( $result['data'][0]['relationships']['order/base/product'] ) );
+		$this->assertEquals( 6, count( $result['data'][0]['relationships']['order/base/product']['data'] ) );
 		$this->assertEquals( 7, count( $result['included'] ) );
 
 		$this->assertArrayNotHasKey( 'errors', $result );
@@ -81,7 +81,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$this->assertGreaterThanOrEqual( 4, count( $result['data'] ) );
 		$this->assertEquals( 'order/base', $result['data'][0]['type'] );
 		$this->assertEquals( 2, count( $result['data'][0]['attributes'] ) );
-		$this->assertGreaterThanOrEqual( 4, count( $result['data'][0]['relationships']['order/base/product'] ) );
+		$this->assertGreaterThanOrEqual( 4, count( $result['data'][0]['relationships']['order/base/product']['data'] ) );
 		$this->assertGreaterThanOrEqual( 14, count( $result['included'] ) );
 		$this->assertGreaterThanOrEqual( 2, count( $result['included'][0]['attributes'] ) );
 


### PR DESCRIPTION
The relationships structure in get requests for catalog (and order and site) is incorrect, with the `data` field inside each item in the array instead of one `data` with an array of items.

Similar to 4bc83dda20aca4b0001cf04a7ebaf98ae6adc97e which fixed this in the main template, this applies the same fix to all partial templates: catalog, order and site.